### PR TITLE
fix: auth flow bugs and playwright test issues

### DIFF
--- a/src/Http/Controllers/CredentialController.php
+++ b/src/Http/Controllers/CredentialController.php
@@ -259,7 +259,7 @@ class CredentialController extends Controller
 
         $keyOrder = ['name', 'locale', 'primary', 'published'];
 
-        $languages = json_decode($requestData['storeLocales'], true);
+        $languages = json_decode($requestData['storeLocales'] ?? '[]', true) ?? [];
 
         $languages = array_map(function ($item) use ($keyOrder) {
             return array_merge(array_flip($keyOrder), $item);

--- a/src/Http/Requests/CredentialForm.php
+++ b/src/Http/Requests/CredentialForm.php
@@ -16,8 +16,8 @@ class CredentialForm extends FormRequest
         return [
             'shopUrl'      => 'required|unique:wk_shopify_credentials_config',
             'accessToken'  => 'nullable|required_without_all:clientId,clientSecret',
-            'clientId'     => 'nullable|required_without:accessToken',
-            'clientSecret' => 'nullable|required_without:accessToken',
+            'clientId'     => 'nullable|required_without:accessToken|required_with:clientSecret',
+            'clientSecret' => 'nullable|required_without:accessToken|required_with:clientId',
             'apiVersion'   => 'required',
         ];
     }

--- a/src/Services/ShopifyTokenService.php
+++ b/src/Services/ShopifyTokenService.php
@@ -29,7 +29,7 @@ class ShopifyTokenService
         try {
             $response = Http::asForm()
                 ->timeout(30)
-                ->retry(3, 500)
+                ->retry(3, 500, fn ($e) => $e instanceof \Illuminate\Http\Client\ConnectionException)
                 ->post($tokenUrl, [
                     'grant_type'    => 'client_credentials',
                     'client_id'     => $clientId,

--- a/src/Traits/ShopifyGraphqlRequest.php
+++ b/src/Traits/ShopifyGraphqlRequest.php
@@ -69,28 +69,16 @@ trait ShopifyGraphqlRequest
 
                     return $model->accessToken;
                 } catch (\Illuminate\Contracts\Encryption\DecryptException $e) {
-                    // Encrypted values may be corrupted (e.g., stored without going through the cast).
-                    // Attempt recovery using raw DB values.
-                    $rawSecret = $model->getRawOriginal('clientSecret');
-
-                    if ($model->clientId && $rawSecret) {
-                        $tokenService = app(ShopifyTokenService::class);
-                        $tokenData = $tokenService->fetchToken($model->shopUrl, $model->clientId, $rawSecret);
-
-                        // Re-save through the model so the encrypted cast properly encrypts the values
-                        $model->forceFill([
-                            'clientSecret'   => $rawSecret,
-                            'accessToken'    => $tokenData['access_token'],
-                            'tokenExpiresAt' => \Illuminate\Support\Carbon::now()->addSeconds(($tokenData['expires_in'] ?? 86399) - 60),
-                        ])->save();
-
-                        return $tokenData['access_token'];
-                    }
-
-                    // For non-OAuth credentials, try the raw accessToken value
+                    // Decryption failed — the stored ciphertext is unreadable (e.g., key rotation).
+                    // The raw DB values are encrypted blobs and cannot be used directly as credentials.
+                    // Attempt to decrypt the raw accessToken as a last resort.
                     $rawToken = $model->getRawOriginal('accessToken');
                     if ($rawToken) {
-                        return $rawToken;
+                        try {
+                            return decrypt($rawToken);
+                        } catch (\Illuminate\Contracts\Encryption\DecryptException $inner) {
+                            // Value is unrecoverable — re-throw original exception.
+                        }
                     }
 
                     throw $e;

--- a/tests/e2e-pw/tests/setup/global-setup.js
+++ b/tests/e2e-pw/tests/setup/global-setup.js
@@ -1,8 +1,8 @@
-import { chromium } from '@playwright/test';
+import { firefox } from '@playwright/test';
 import fs from 'fs';
 
 async function globalSetup() {
-    const browser = await chromium.launch(); // Use chromium, Playwright handles cross-browser storage
+    const browser = await firefox.launch();
     const context = await browser.newContext();
     const page = await context.newPage();
 
@@ -23,7 +23,7 @@ async function globalSetup() {
         throw new Error('Auth storage file was not created.');
     }
 
-    // await browser.close();
+    await browser.close();
 }
 
 export default globalSetup;

--- a/tests/e2e-pw/tests/shopify/credential/shopify-credentials.spec.js
+++ b/tests/e2e-pw/tests/shopify/credential/shopify-credentials.spec.js
@@ -98,9 +98,13 @@ test.describe.serial('Shopify Create credential Page', () => {
   });
 
   test('Credential creation with the valid data', async ({ page }) => {
+    const shopUrl = process.env.E2E_SHOPIFY_URL;
+    const accessToken = process.env.E2E_SHOPIFY_TOKEN;
+    test.skip(!shopUrl || !accessToken, 'Shopify credentials not configured: set E2E_SHOPIFY_URL and E2E_SHOPIFY_TOKEN env vars');
+
     await page.getByRole('button', { name: 'Create Credential' }).click();
-    await page.getByRole('textbox', { name: 'http://demo.myshopify.com' }).fill('http://quickstart-c2b9e6cf.myshopify.com');
-    await page.getByRole('textbox', { name: 'Admin API access token' }).fill('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');
+    await page.getByRole('textbox', { name: 'http://demo.myshopify.com' }).fill(shopUrl);
+    await page.getByRole('textbox', { name: 'Admin API access token' }).fill(accessToken);
     await page.getByRole('button', { name: 'Save' }).click();
     await expect(page.getByRole('banner')).toBeVisible();
     await expect(page.locator('body')).toContainText('Credential Created Success');
@@ -133,7 +137,9 @@ test.describe.serial('Shopify Create credential Page', () => {
   });
 
   test('Delete the credential', async ({ page }) => {
-    await expect(page.locator('#app')).toContainText('http://quickstart-c2b9e6cf.myshopify.com');
+    const shopUrl = process.env.E2E_SHOPIFY_URL;
+    test.skip(!shopUrl, 'Shopify credentials not configured: set E2E_SHOPIFY_URL env var');
+    await expect(page.locator('#app')).toContainText(shopUrl);
     await expect(page.getByTitle('Delete')).toBeVisible();
     await page.getByTitle('Delete').click();
     await expect(page.getByText('Are you sure you want to')).toBeVisible();


### PR DESCRIPTION
Fixes #2

## Summary

- Fix `retry()` in `ShopifyTokenService` to only retry on connection failures, making 401/403 error handlers reachable
- Remove broken `DecryptException` recovery that sent encrypted DB ciphertext as OAuth `client_secret` (root cause of the 400 errors)
- Add null guard for `storeLocales` in `CredentialController`
- Fix `CredentialForm` validation to require `clientId` and `clientSecret` together
- Replace hardcoded Shopify token in Playwright tests with env vars (`E2E_SHOPIFY_URL`, `E2E_SHOPIFY_TOKEN`)
- Fix Playwright global-setup to use Firefox (matches test projects) and close browser

Generated with [Claude Code](https://claude.ai/code)