### PR TITLE
fix: resolve 'The MAC is invalid' error during import

### DIFF
--- a/src/Database/Migration/2026_03_15_000001_update_shopify_credentials_for_oauth.php
+++ b/src/Database/Migration/2026_03_15_000001_update_shopify_credentials_for_oauth.php
@@ -21,12 +21,37 @@ return new class extends Migration
             $table->timestamp('tokenExpiresAt')->nullable()->after('accessToken');
         });
 
-        // Encrypt existing plaintext accessToken values so they work with the encrypted cast
+        // Encrypt existing plaintext accessToken values so they work with the encrypted cast.
+        // Uses Crypt::encrypt() (with PHP serialization) to match the model's 'encrypted' cast,
+        // which reads values via Crypt::decrypt() with $unserialize = true.
         DB::table('wk_shopify_credentials_config')->orderBy('id')->each(function ($credential) {
+            if (! $credential->accessToken) {
+                return;
+            }
+
+            // Skip rows that are already properly encrypted (idempotency guard).
+            // A value encrypted with Crypt::encrypt() will decrypt successfully here.
+            try {
+                Crypt::decrypt($credential->accessToken);
+
+                return; // Already encrypted with the correct method, skip.
+            } catch (\Exception $e) {
+                // Not yet encrypted (or encrypted with encryptString); proceed.
+            }
+
+            // If the value was previously encrypted with Crypt::encryptString(), recover the
+            // plain-text token first so we can re-encrypt it with the correct method.
+            $plainToken = $credential->accessToken;
+            try {
+                $plainToken = Crypt::decryptString($credential->accessToken);
+            } catch (\Exception $e) {
+                // Value is plain text — use it as-is.
+            }
+
             DB::table('wk_shopify_credentials_config')
                 ->where('id', $credential->id)
                 ->update([
-                    'accessToken' => Crypt::encryptString($credential->accessToken),
+                    'accessToken' => Crypt::encrypt($plainToken),
                 ]);
         });
     }
@@ -36,15 +61,31 @@ return new class extends Migration
      */
     public function down(): void
     {
-        // Decrypt accessToken values back to plaintext before removing encrypted cast columns
+        // Decrypt accessToken values back to plaintext before removing encrypted cast columns.
         DB::table('wk_shopify_credentials_config')->orderBy('id')->each(function ($credential) {
+            if (! $credential->accessToken) {
+                return;
+            }
+
+            // Try Crypt::decrypt() first (matches up() which uses Crypt::encrypt()).
+            try {
+                $decrypted = Crypt::decrypt($credential->accessToken);
+                DB::table('wk_shopify_credentials_config')
+                    ->where('id', $credential->id)
+                    ->update(['accessToken' => $decrypted]);
+
+                return;
+            } catch (\Exception $e) {
+                // Not encrypted with Crypt::encrypt(); try the older encryptString format.
+            }
+
             try {
                 $decrypted = Crypt::decryptString($credential->accessToken);
                 DB::table('wk_shopify_credentials_config')
                     ->where('id', $credential->id)
                     ->update(['accessToken' => $decrypted]);
             } catch (\Exception $e) {
-                // Already plaintext, skip
+                // Already plaintext or unreadable; skip.
             }
         });
 

--- a/src/Traits/ShopifyGraphqlRequest.php
+++ b/src/Traits/ShopifyGraphqlRequest.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Shopify\Traits;
 
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage as StorageFacade;
 use Webkul\DataTransfer\Helpers\Export as ExportHelper;
@@ -67,21 +68,31 @@ trait ShopifyGraphqlRequest
                         return $tokenService->refreshIfNeeded($model);
                     }
 
-                    return $model->accessToken;
-                } catch (\Illuminate\Contracts\Encryption\DecryptException $e) {
-                    // Decryption failed — the stored ciphertext is unreadable (e.g., key rotation).
-                    // The raw DB values are encrypted blobs and cannot be used directly as credentials.
-                    // Attempt to decrypt the raw accessToken as a last resort.
-                    $rawToken = $model->getRawOriginal('accessToken');
-                    if ($rawToken) {
-                        try {
-                            return decrypt($rawToken);
-                        } catch (\Illuminate\Contracts\Encryption\DecryptException $inner) {
-                            // Value is unrecoverable — re-throw original exception.
+                    $token = $model->accessToken;
+
+                    // Handle the case where the token was encrypted without PHP serialization
+                    // (e.g. via Crypt::encryptString() in older migrations). In this case
+                    // decrypt() returns false instead of the actual token string.
+                    if ($token === false || $token === null) {
+                        $rawToken = $model->getRawOriginal('accessToken');
+                        if ($rawToken) {
+                            return Crypt::decryptString($rawToken);
                         }
+
+                        throw new InvalidCredential(
+                            'No valid access token found. Please re-save your Shopify credentials.'
+                        );
                     }
 
-                    throw $e;
+                    return $token;
+                } catch (\Illuminate\Contracts\Encryption\DecryptException $e) {
+                    // Decryption failed — the APP_KEY has likely changed since the credentials
+                    // were saved (e.g. after running php artisan key:generate).
+                    throw new InvalidCredential(
+                        'Shopify credentials cannot be decrypted. This is usually caused by the '
+                        .'application encryption key (APP_KEY) changing after the credentials were '
+                        .'saved. Please re-save your Shopify credentials to resolve this issue.'
+                    );
                 }
             }
         }


### PR DESCRIPTION
Fixes two bugs that caused credential decryption to fail during Shopify import, surfacing as the cryptic "The MAC is invalid" error.

## Changes

**Migration fix**: Changed `Crypt::encryptString()` to `Crypt::encrypt()` to match the model's `encrypted` cast, and made the migration idempotent.

**Error handling fix**: Replaced the useless `decrypt($rawToken)` fallback with a `Crypt::decryptString()` backward-compatibility fallback, and a clear user-facing error message when APP_KEY has changed.

Closes #4

Generated with [Claude Code](https://claude.ai/code)